### PR TITLE
fix redis wrapper to be compliant with python35

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,8 @@ jobs:
             sudo tar -C /usr/local -xzf go1.12.linux-amd64.tar.gz
             echo 'export PATH="$PATH:/usr/local/go/bin"' >> $BASH_ENV
       - run: go get -u gopkg.in/launchdarkly/ld-relay.v5/...
+      - run: pipenv install -d -e .
+      - run: pipenv run rc
       - run:
           name: Generate Relay Config
           command: pipenv run rc generate-relay-config -p support-service
@@ -22,8 +24,6 @@ jobs:
           name: Start LD Relay
           command: $GOPATH/bin/ld-relay --config ./ld-relay.conf
           background: true
-      - run: pipenv install -d -e .
-      - run: pipenv run rc
       - run:
           name: Run Test Suite
           command: |
@@ -51,6 +51,8 @@ jobs:
             sudo tar -C /usr/local -xzf go1.12.linux-amd64.tar.gz
             echo 'export PATH="$PATH:/usr/local/go/bin"' >> $BASH_ENV
       - run: go get -u gopkg.in/launchdarkly/ld-relay.v5/...
+      - run: pipenv install -d -e .
+      - run: pipenv run rc
       - run:
           name: Generate Relay Config
           command: pipenv run rc generate-relay-config -p support-service
@@ -58,8 +60,6 @@ jobs:
           name: Start LD Relay
           command: $GOPATH/bin/ld-relay --config ./ld-relay.conf
           background: true
-      - run: pipenv install -d -e .
-      - run: pipenv run rc
       - run:
           name: Run Test Suite
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,12 +15,6 @@ jobs:
             sudo tar -C /usr/local -xzf go1.12.linux-amd64.tar.gz
             echo 'export PATH="$PATH:/usr/local/go/bin"' >> $BASH_ENV
       - run: go get -u gopkg.in/launchdarkly/ld-relay.v5/...
-      - run: pipenv install -d -e .
-      - run: pipenv run rc
-      - run:
-          name: Run Test Suite
-          command: |
-            pipenv run make test
       - run:
           name: Generate Relay Config
           command: pipenv run rc generate-relay-config -p support-service
@@ -28,6 +22,12 @@ jobs:
           name: Start LD Relay
           command: $GOPATH/bin/ld-relay --config ./ld-relay.conf
           background: true
+      - run: pipenv install -d -e .
+      - run: pipenv run rc
+      - run:
+          name: Run Test Suite
+          command: |
+            pipenv run make test
       - run:
           name: Run Integration Tests
           command: pipenv run make integration
@@ -51,12 +51,6 @@ jobs:
             sudo tar -C /usr/local -xzf go1.12.linux-amd64.tar.gz
             echo 'export PATH="$PATH:/usr/local/go/bin"' >> $BASH_ENV
       - run: go get -u gopkg.in/launchdarkly/ld-relay.v5/...
-      - run: pipenv install -d -e .
-      - run: pipenv run rc
-      - run:
-          name: Run Test Suite
-          command: |
-            pipenv run make test
       - run:
           name: Generate Relay Config
           command: pipenv run rc generate-relay-config -p support-service
@@ -64,6 +58,12 @@ jobs:
           name: Start LD Relay
           command: $GOPATH/bin/ld-relay --config ./ld-relay.conf
           background: true
+      - run: pipenv install -d -e .
+      - run: pipenv run rc
+      - run:
+          name: Run Test Suite
+          command: |
+            pipenv run make test
       - run:
           name: Run Integration Tests
           command: pipenv run make integration

--- a/relay_commander/redis.py
+++ b/relay_commander/redis.py
@@ -16,6 +16,7 @@ class RedisConention():
     :param host: hostname for redis
     :param port: port for redis
     """
+
     def __init__(self, host, port):
         self.host = host
         self.port = port
@@ -28,6 +29,7 @@ class RedisWrapper():
     :param environmentKey: LaunchDarkly environment key.
     :param conn: (optional) redis connection string
     """
+
     def __init__(self, host, port, logger, projectKey, environmentKey):
         self.logger = logger
         self.projectKey = projectKey
@@ -55,7 +57,7 @@ class RedisWrapper():
         rawConnections = uri.split(',')
         connections = [
             connection for connection in rawConnections if len(connection) > 0
-            ]
+        ]
 
         for connection in connections:
             rawConnection = connection.split(':')
@@ -93,7 +95,7 @@ class RedisWrapper():
         :param featureKey: key for feature flag
         """
         keyName = self._formatKeyName()
-        parsedFlag = json.loads(self.getFlagRecord(featureKey))
+        parsedFlag = json.loads(self.getFlagRecord(featureKey).decode('utf-8'))
         parsedFlag['on'] = state
         parsedFlag['version'] += 1
 


### PR DESCRIPTION
When running in python35 this module resulted in an error 

```
TypeError: the JSON object must be str, not 'bytes'
```

We need to encode the JSON loads to prevent this from happening. Python36 and above are able to handle both bytes and strings. This solution works for all versions. 