### PR TITLE
Add try/except to LaunchDarkly API calls.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,15 +9,20 @@ Version 0.0.12
 UNRELEASED
 
 Core CLI:
+  * Implement environment variable validator to ensure that required
+    environment variables are set in the environment.
+  * Implement helpers for version checking and logging.
+  * Add try/except logic for all calls to the LaunchDarkly API. Any exceptions
+    coming from the LaunchDarkly API were previously uncaught.
 
 Developer Experience:
-    * Add sphinx-click extension which allows us to automatically generate
-      documentation for our click based CLI using sphinx.
-    * Switch away from ``pipenv``. This was causing a few more problems than
-      it was solving, so we moved back to using a standard virtualenv, pip,
-      and requirements.txt file.
-    * Refactor everything for `PEP-8 <https://www.python.org/dev/peps/pep-0008/>`_
-      and `PEP-484 <https://www.python.org/dev/peps/pep-0484/>`_.
+  * Add sphinx-click extension which allows us to automatically generate
+    documentation for our click based CLI using sphinx.
+  * Switch away from ``pipenv``. This was causing a few more problems than
+    it was solving, so we moved back to using a standard virtualenv, pip,
+    and requirements.txt file.
+  * Refactor everything for `PEP-8 <https://www.python.org/dev/peps/pep-0008/>`_
+    and `PEP-484 <https://www.python.org/dev/peps/pep-0484/>`_.
 
 Version 0.0.11
 --------------


### PR DESCRIPTION
This will stop execution in the event that the API key
provided is either wrong or does not have the correct
permissions to execute the requested function.

fixes: #10